### PR TITLE
Fix context menu not working

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,12 @@
         <category android:name="android.intent.category.DEFAULT"/>
         <data android:mimeType="text/plain"/>
       </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https" />
+      </intent-filter>
     </activity-alias>
 
     <activity-alias

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-  id("com.android.application") version "7.4.0-beta02" apply false
-  id("com.android.library") version "7.4.0-beta02" apply false
+  id("com.android.application") version "7.4.2" apply false
+  id("com.android.library") version "7.4.2" apply false
   id("org.jetbrains.kotlin.android") version "1.7.10" apply false
 }


### PR DESCRIPTION
The context menu no longer works in certain apps (namely, the latest beta version of AnkiDroid.) I'm honestly not sure why it no longer works, and I also have no idea why this change even fixes it, but I copied/pasted [this answer](https://stackoverflow.com/a/72930519) and everything magically works for some crazy reason.

Tested on AnkiDroid, Chrome, Firefox, Kiwi Browser. Currently trying to send it out for others to test to make sure it doesn't break any existing functionality, hence why it's a draft PR right now.

Full discussion on [TMW discord](https://discord.com/channels/617136488840429598/1051666084840886412/1107583399201353817), in the textbender thread.
